### PR TITLE
Fix docker compose quoting and add frontend Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile.backend
     ports:
-      - ""8000:8000""
+      - "8000:8000"
     env_file:
       - .env.example
     volumes:
@@ -16,6 +16,6 @@ services:
       context: ./frontend
       dockerfile: Dockerfile.frontend
     ports:
-      - ""3000:3000""
+      - "3000:3000"
     volumes:
       - ./frontend:/usr/src/app

--- a/frontend/Dockerfile.frontend
+++ b/frontend/Dockerfile.frontend
@@ -1,0 +1,13 @@
+# Stage 1: build the React app
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: serve the app with nginx
+FROM nginx:stable-alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add a Dockerfile for the frontend app
- fix container port definitions in `docker-compose.yml`

## Testing
- `npm ci --prefix frontend`
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6877b1431348832cb7baffc809d985d4