### PR TITLE
Remove .env from repo, add example

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-﻿MODEL_NAME=knoksen/darkbert-approved
-DATABASE_URL=sqlite:///./data.db
-
-HUGGINGFACE_HUB_TOKEN=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

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-﻿MODEL_NAME=knoksen/darkbert-approved
+MODEL_NAME=knoksen/darkbert-approved
 DATABASE_URL=sqlite:///./data.db
+HUGGINGFACE_HUB_TOKEN=your_token_here


### PR DESCRIPTION
## Summary
- removed `.env` from version control
- added token placeholder to `.env.example`
- confirmed `.gitignore` contains `.env`

## Testing
- `npm ci`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6877b14042e4832cb815967e76312a76