### PR TITLE
Add Unity desktop configuration

### DIFF
--- a/Assets/Scripts/DashboardController.cs
+++ b/Assets/Scripts/DashboardController.cs
@@ -1,7 +1,8 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.Networking;
 using TMPro;
 using System.Collections;
+using System.IO;
 
 public class DashboardController : MonoBehaviour
 {
@@ -10,10 +11,41 @@ public class DashboardController : MonoBehaviour
     public TMP_InputField inferenceInput;
     public TMP_Text inferenceOutput;
 
+    private string baseUrl;
+
     void Start()
     {
+        baseUrl = LoadBackendUrl();
         StartCoroutine(FetchMetrics());
         StartCoroutine(FetchConfusion());
+    }
+
+    string LoadBackendUrl()
+    {
+        string defaultUrl = "http://localhost:8000";
+        string playerPrefUrl = PlayerPrefs.GetString("backend_url", null);
+        if (!string.IsNullOrEmpty(playerPrefUrl))
+            return playerPrefUrl;
+
+        string configPath = Path.Combine(Application.streamingAssetsPath, "backend_config.json");
+        if (File.Exists(configPath))
+        {
+            try
+            {
+                var json = File.ReadAllText(configPath);
+                var cfg = JsonUtility.FromJson<BackendConfig>(json);
+                if (cfg != null && !string.IsNullOrEmpty(cfg.base_url))
+                    return cfg.base_url;
+            }
+            catch { }
+        }
+        return defaultUrl;
+    }
+
+    [System.Serializable]
+    class BackendConfig
+    {
+        public string base_url;
     }
 
     public void OnPredictButton()
@@ -23,7 +55,7 @@ public class DashboardController : MonoBehaviour
 
     IEnumerator FetchMetrics()
     {
-        using var req = UnityWebRequest.Get(\"http://localhost:8000/metrics\");
+        using var req = UnityWebRequest.Get(baseUrl + "/metrics");
         yield return req.SendWebRequest();
         if (req.result == UnityWebRequest.Result.Success)
             metricsText.text = req.downloadHandler.text;
@@ -31,7 +63,7 @@ public class DashboardController : MonoBehaviour
 
     IEnumerator FetchConfusion()
     {
-        using var req = UnityWebRequest.Get(\"http://localhost:8000/confusion\");
+        using var req = UnityWebRequest.Get(baseUrl + "/confusion");
         yield return req.SendWebRequest();
         if (req.result == UnityWebRequest.Result.Success)
             confusionText.text = req.downloadHandler.text;
@@ -40,11 +72,11 @@ public class DashboardController : MonoBehaviour
     IEnumerator Predict(string text)
     {
         var payload = JsonUtility.ToJson(new { text });
-        using var req = new UnityWebRequest(\"http://localhost:8000/predict\", \"POST\");
+        using var req = new UnityWebRequest(baseUrl + "/predict", "POST");
         byte[] body = System.Text.Encoding.UTF8.GetBytes(payload);
         req.uploadHandler = new UploadHandlerRaw(body);
         req.downloadHandler = new DownloadHandlerBuffer();
-        req.SetRequestHeader(\"Content-Type\", \"application/json\");
+        req.SetRequestHeader("Content-Type", "application/json");
         yield return req.SendWebRequest();
         if (req.result == UnityWebRequest.Result.Success)
             inferenceOutput.text = req.downloadHandler.text;

--- a/Assets/Scripts/DashboardController.cs
+++ b/Assets/Scripts/DashboardController.cs
@@ -69,9 +69,15 @@ public class DashboardController : MonoBehaviour
             confusionText.text = req.downloadHandler.text;
     }
 
+    [System.Serializable]
+    class PredictRequest
+    {
+        public string text;
+    }
+
     IEnumerator Predict(string text)
     {
-        var payload = JsonUtility.ToJson(new { text });
+        var payload = JsonUtility.ToJson(new PredictRequest { text = text });
         using var req = new UnityWebRequest(baseUrl + "/predict", "POST");
         byte[] body = System.Text.Encoding.UTF8.GetBytes(payload);
         req.uploadHandler = new UploadHandlerRaw(body);

--- a/Assets/StreamingAssets/backend_config.json
+++ b/Assets/StreamingAssets/backend_config.json
@@ -1,0 +1,3 @@
+{
+  "base_url": "http://localhost:8000"
+}

--- a/README.md
+++ b/README.md
@@ -57,3 +57,22 @@ Make sure you have created a `.env` file containing at least `MODEL_NAME` and
 docker-compose up --build
 ```
 
+
+## Unity Desktop App
+
+A minimal Unity project is provided in the `Assets` folder. It contains a
+`DashboardController` script under `Assets/Scripts` and the UI layout in
+`Assets/UI`. An example configuration file `Assets/StreamingAssets/backend_config.json`
+controls which backend the desktop build communicates with.
+
+To change the backend URL edit the JSON file and set the `base_url` value or set
+`PlayerPrefs` key `backend_url` at runtime.
+
+To build the desktop app for Windows 10:
+
+1. Open the Unity editor.
+2. Import the `Assets` folder from this repository.
+3. Modify the backend URL in the configuration file if needed.
+4. Choose build target **PC, Mac & Linux Standalone → Windows** and build.
+
+


### PR DESCRIPTION
## Summary
- add configurable backend URL for Unity desktop app
- provide `backend_config.json` with default URL
- document Unity desktop build steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877e9b52dd8832c9afb90c377cf9c6b