### PR TITLE
Update env variables for dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 MODEL_NAME=knoksen/darkbert-approved
 DATABASE_URL=sqlite:///./data.db
 HUGGINGFACE_HUB_TOKEN=your_token_here
+
+VITE_API_BASE_URL=http://localhost:8000
+VITE_DARK_MODE=false

--- a/README.md
+++ b/README.md
@@ -53,8 +53,14 @@ uvicorn app.main:app --reload
 
 ### Docker Compose
 
-Make sure you have created a `.env` file containing at least `MODEL_NAME`, `HUGGINGFACE_HUB_TOKEN`, `VITE_API_BASE_URL` and `VITE_DARK_MODE` and then build and start both services:
+Make sure you have created a `.env` file containing the following variables:
 
+- `MODEL_NAME`
+- `HUGGINGFACE_HUB_TOKEN`
+- `VITE_API_BASE_URL`
+- `VITE_DARK_MODE`
+
+Then, build and start both services:
 ```bash
 docker-compose up --build
 ```

--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ npm install
 pip install -r requirements.txt
 ```
 
-Copy the example environment file and add your HuggingFace token:
+Copy the example environment file and update the environment variables:
 
 ```bash
 cp .env.example .env
-# edit .env and set HUGGINGFACE_HUB_TOKEN, e.g., HUGGINGFACE_HUB_TOKEN=your_token_here
+# edit .env and set values such as
+# HUGGINGFACE_HUB_TOKEN=your_token_here
+# VITE_API_BASE_URL=http://localhost:8000
+# VITE_DARK_MODE=false
 ```
 
 Start the frontend development server:
@@ -50,8 +53,7 @@ uvicorn app.main:app --reload
 
 ### Docker Compose
 
-Make sure you have created a `.env` file containing at least `MODEL_NAME` and
-`HUGGINGFACE_HUB_TOKEN` and then build and start both services:
+Make sure you have created a `.env` file containing at least `MODEL_NAME`, `HUGGINGFACE_HUB_TOKEN`, `VITE_API_BASE_URL` and `VITE_DARK_MODE` and then build and start both services:
 
 ```bash
 docker-compose up --build


### PR DESCRIPTION
## Summary
- include `VITE_API_BASE_URL` and `VITE_DARK_MODE` defaults in `.env.example`
- document new env vars in setup instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68797b5a7764832cbbbb6a360aef13f8