### PR TITLE
Update dark mode toggle

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ const Header: React.FC = () => {
           DarkBERT Dashboard
         </Typography>
         <IconButton onClick={darkMode.toggle}>
-          {darkMode.value ? <LightMode /> : <DarkMode />}
+          {darkMode.enabled ? <LightMode /> : <DarkMode />}
         </IconButton>
       </Toolbar>
     </AppBar>

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 export default function useDarkMode(initial = false) {
-  const [enabled, setEnabled] = useState(() => {
+  const [enabled, setEnabled] = useState<boolean>(() => {
     const storedPreference = localStorage.getItem('dark-mode')
     return storedPreference !== null ? JSON.parse(storedPreference) : initial
   })
@@ -18,7 +18,7 @@ export default function useDarkMode(initial = false) {
     }
   }, [enabled])
 
-  const toggle = () => setEnabled((prev) => !prev)
+  const toggle = () => setEnabled((prev: boolean) => !prev)
 
   return { enabled, toggle }
 }

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -18,7 +18,7 @@ export default function useDarkMode(initial = false) {
     }
   }, [enabled])
 
-  const toggle = () => setEnabled((prev: boolean) => !prev)
+  const toggle = () => setEnabled((prev) => !prev)
 
   return { enabled, toggle }
 }


### PR DESCRIPTION
## Summary
- change dark mode check in `Header` to use `enabled`
- add types to `useDarkMode`

## Testing
- `npm run build`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6879edb859b0832c9e3709011178b2f0